### PR TITLE
Rename MissionchiefBot references to MscBot

### DIFF
--- a/Launch.ps1
+++ b/Launch.ps1
@@ -12,7 +12,7 @@ $root = $PSScriptRoot
 if (-not $root) { $root = Split-Path -Parent $MyInvocation.MyCommand.Definition }
 Set-Location $root
 
-Write-Host "== MissionchiefBot-X launcher =="
+Write-Host "== MscBot launcher =="
 
 # --- ensure venv
 $venvPy = ".\.venv\Scripts\python.exe"

--- a/Main.py
+++ b/Main.py
@@ -45,7 +45,10 @@ def _read_version():
 def _check_update():
     try:
         repo = get_update_repo()
-        req = urllib.request.Request(f"https://api.github.com/repos/{repo}/releases/latest", headers={"User-Agent":"MissionchiefBot-X"})
+        req = urllib.request.Request(
+            f"https://api.github.com/repos/{repo}/releases/latest",
+            headers={"User-Agent": "MscBot"},
+        )
         with urllib.request.urlopen(req, timeout=5) as r:
             data = json.loads(r.read().decode("utf-8"))
             latest = (data.get("tag_name") or "").strip()
@@ -85,7 +88,7 @@ async def mission_logic(browsers_for_missions):
             display_error(f"Error in mission logic: {e}")
 
 async def main():
-    display_info("MissionchiefBot-X starting…")
+    display_info("MscBot starting…")
     _validate_or_die()
     _check_update()
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Missionchief Bot v1.0
+# MscBot v1.0
 Maintainer: **HGFantasy** — License: **MIT**
 
 ## Quickstart (Windows PowerShell)

--- a/data/config_settings.py
+++ b/data/config_settings.py
@@ -75,7 +75,7 @@ else:
             "cool_down_good_seconds": "120"
         },
         "update": {
-            "repo": "HGFantasy/MissionchiefBot-X"
+            "repo": "HGFantasy/MscBot"
         }
     })
 
@@ -184,4 +184,4 @@ def get_backoff_config():
         "cool_down_good_seconds": _getint("backoff","cool_down_good_seconds", 120),
     }
 
-def get_update_repo(): return _get("update","repo","HGFantasy/MissionchiefBot-X")
+def get_update_repo(): return _get("update","repo","HGFantasy/MscBot")

--- a/utils/eta_filter.py
+++ b/utils/eta_filter.py
@@ -1,5 +1,5 @@
 
-# Project: MissionchiefBot-X — ETA & destination helpers
+# Project: MscBot — ETA & destination helpers
 # License: MIT
 
 import re, math

--- a/utils/humanize.py
+++ b/utils/humanize.py
@@ -1,5 +1,5 @@
 
-# Project: MissionchiefBot-X
+# Project: MscBot
 # License: MIT
 
 import asyncio, random, datetime as dt

--- a/utils/personnel_options.py
+++ b/utils/personnel_options.py
@@ -1,4 +1,4 @@
-# Project: MissionchiefBot-X
+# Project: MscBot
 # Maintained by: HGFantasy
 # License: MIT (see LICENSE)
 # Note: Use responsibly and in accordance with the website's Terms of Service.

--- a/utils/politeness.py
+++ b/utils/politeness.py
@@ -1,5 +1,5 @@
 
-# Project: MissionchiefBot-X
+# Project: MscBot
 # License: MIT
 
 import asyncio, random, time

--- a/utils/pretty_print.py
+++ b/utils/pretty_print.py
@@ -1,5 +1,5 @@
 
-# Project: MissionchiefBot-X
+# Project: MscBot
 # Maintained by: HGFantasy
 # License: MIT
 

--- a/utils/runtime_flags.py
+++ b/utils/runtime_flags.py
@@ -1,5 +1,5 @@
 
-# Project: MissionchiefBot-X
+# Project: MscBot
 # License: MIT
 
 import asyncio, os

--- a/utils/schedule_windows.py
+++ b/utils/schedule_windows.py
@@ -1,5 +1,5 @@
 
-# Project: MissionchiefBot-X — Scheduling windows
+# Project: MscBot — Scheduling windows
 # License: MIT
 
 import asyncio, datetime as dt

--- a/utils/transport.py
+++ b/utils/transport.py
@@ -1,4 +1,4 @@
-# Project: MissionchiefBot-X — Transports (escalation + SLA + adaptive pacing + sentinel + reauth)
+# Project: MscBot — Transports (escalation + SLA + adaptive pacing + sentinel + reauth)
 # License: MIT
 
 from __future__ import annotations

--- a/utils/vehicle_data.py
+++ b/utils/vehicle_data.py
@@ -1,5 +1,5 @@
 
-# Project: MissionchiefBot-X
+# Project: MscBot
 # License: MIT
 
 import json, os

--- a/utils/vehicle_options.py
+++ b/utils/vehicle_options.py
@@ -1,4 +1,4 @@
-# Project: MissionchiefBot-X
+# Project: MscBot
 # Maintained by: HGFantasy
 # License: MIT (see LICENSE)
 # Note: Use responsibly and in accordance with the website's Terms of Service.


### PR DESCRIPTION
## Summary
- Rename Missionchief Bot mentions to MscBot across docs, scripts, and utilities
- Point configuration update repo to HGFantasy/MscBot and adjust user agent
- Ensure HGFantasy remains sole credited maintainer

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68977dc5c0e48322ac68b681cdf78865