### PR TITLE
Fix dynamic config reload and clean up main loop

### DIFF
--- a/agents/dynamic_config.py
+++ b/agents/dynamic_config.py
@@ -49,6 +49,3 @@ class DynamicConfigAgent(BaseAgent):
             except Exception as e:
                 display_error(f"DynamicConfigAgent reload failed: {e}")
 
-        except Exception as e:
-            display_error(f"DynamicConfigAgent reload failed: {e}")
-


### PR DESCRIPTION
## Summary
- remove stray except block causing dynamic_config syntax error
- clean up Main logic and drop undefined human pacing calls

## Testing
- `python -m py_compile agents/dynamic_config.py Main.py`
- `python - <<'PY'
import Main
print('imported')
PY`

------
https://chatgpt.com/codex/tasks/task_e_68990abdcb788322a6533989b1f24276