### PR TITLE
Restart bot after auto-update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Reworked update check to track main repository commits and auto-update on startup.
+- Auto-update now pulls new files and restarts the bot when updates are detected.
 
 ## 2025-08-10 — v2.0
 

--- a/agents/update_check.py
+++ b/agents/update_check.py
@@ -2,7 +2,9 @@
 from __future__ import annotations
 
 import json
+import os
 import subprocess
+import sys
 import time
 import urllib.request
 
@@ -30,7 +32,7 @@ class UpdateCheckAgent(BaseAgent):
     async def _maybe_check(self) -> None:
         if time.time() >= self._next_check:
             self._next_check = time.time() + 3600  # once per hour
-            await self._check_now()
+            await self._check_now(auto_update=True)
 
     async def _check_now(self, auto_update: bool = False) -> None:
         try:
@@ -72,6 +74,8 @@ class UpdateCheckAgent(BaseAgent):
                 "pull",
                 f"https://github.com/{repo}.git",
             ], check=True)
-            display_info("Repository auto-updated to latest commit.")
+            display_info("Repository auto-updated to latest commit. Restarting…")
+            python = sys.executable
+            os.execl(python, python, *sys.argv)
         except Exception as e:
             display_error(f"Auto-update failed: {e}")


### PR DESCRIPTION
## Summary
- restart bot after pulling latest code during auto-update
- run auto-update check on periodic checks as well
- document new restart behavior in changelog

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689912058eb48322afa53ffc485ef7af