### PR TITLE
fix: ensure auto update runs from project root

### DIFF
--- a/agents/update_check.py
+++ b/agents/update_check.py
@@ -1,4 +1,5 @@
 """Agent that checks the GitHub repo for newer commits."""
+
 from __future__ import annotations
 
 import json
@@ -8,7 +9,7 @@ import sys
 import time
 import urllib.request
 
-from data.config_settings import get_update_repo
+from data.config_settings import PROJECT_ROOT, get_update_repo
 from utils.pretty_print import display_error, display_info
 
 from .base import BaseAgent
@@ -56,24 +57,23 @@ class UpdateCheckAgent(BaseAgent):
 
     def _local_commit(self) -> str:
         try:
-            return (
-                subprocess.run(
-                    ["git", "rev-parse", "HEAD"],
-                    check=True,
-                    text=True,
-                    capture_output=True,
-                ).stdout.strip()
-            )
+            return subprocess.run(
+                ["git", "rev-parse", "HEAD"],
+                check=True,
+                text=True,
+                capture_output=True,
+                cwd=str(PROJECT_ROOT),
+            ).stdout.strip()
         except Exception:
             return ""
 
     def _auto_update(self, repo: str) -> None:
         try:
-            subprocess.run([
-                "git",
-                "pull",
-                f"https://github.com/{repo}.git",
-            ], check=True)
+            subprocess.run(
+                ["git", "pull", f"https://github.com/{repo}.git"],
+                check=True,
+                cwd=str(PROJECT_ROOT),
+            )
             display_info("Repository auto-updated to latest commit. Restarting…")
             python = sys.executable
             os.execl(python, python, *sys.argv)


### PR DESCRIPTION
## Summary
- fix auto-update not running by invoking git commands in project root
- ensure update checks use configured root path

## Testing
- `black agents/update_check.py`
- `ruff check agents/update_check.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689915b080c88322bb7326a445fad7e1