### PR TITLE
Offload mission priority scoring to Go service

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ For details on writing your own agents, check [agents/README.md](agents/README.m
 
 ## Example: Offloading tasks to Go
 
-A minimal Go service lives under `go_service/` and exposes a `/fib` endpoint.
+A minimal Go service lives under `go_service/` and exposes `/fib` and `/score` endpoints.
 Start it in one terminal:
 
 ```bash
@@ -39,8 +39,9 @@ go run go_service/main.go
 Then from Python you can request the result:
 
 ```python
-from utils.orchestrator_client import get_fibonacci
+from utils.orchestrator_client import get_fibonacci, get_priority_score
 print(get_fibonacci(10))
+print(get_priority_score("Major wildfire"))
 ```
 
 This demonstrates delegating performance-critical work to a faster language

--- a/go_service/main.go
+++ b/go_service/main.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"net/http"
 	"strconv"
+	"strings"
 )
 
 // fib computes the nth Fibonacci number iteratively.
@@ -32,8 +33,41 @@ func fibHandler(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(resp)
 }
 
+// priorityScore assigns points based on mission title keywords.
+func priorityScore(name string) int {
+	n := strings.ToLower(name)
+	keywords := map[string]int{
+		"major":      8,
+		"mass":       8,
+		"large":      6,
+		"multiple":   5,
+		"high-rise":  5,
+		"industrial": 4,
+		"chemical":   4,
+		"airport":    4,
+		"brush":      3,
+		"wildfire":   5,
+	}
+	score := 0
+	for kw, pts := range keywords {
+		if strings.Contains(n, kw) {
+			score += pts
+		}
+	}
+	return score
+}
+
+func scoreHandler(w http.ResponseWriter, r *http.Request) {
+	name := r.URL.Query().Get("name")
+	score := priorityScore(name)
+	resp := map[string]int{"score": score}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(resp)
+}
+
 func main() {
 	http.HandleFunc("/fib", fibHandler)
+	http.HandleFunc("/score", scoreHandler)
 	log.Println("Go service listening on :8080")
 	log.Fatal(http.ListenAndServe(":8080", nil))
 }

--- a/utils/dispatcher.py
+++ b/utils/dispatcher.py
@@ -16,6 +16,7 @@ from utils.metrics import inc, maybe_write
 from utils import sentinel
 from agents.loader import get_agent, emit
 from agents.defer import DeferredMission
+from utils.orchestrator_client import get_priority_score
 from data.config_settings import (
     get_eta_filter,
     get_min_mission_age_seconds,
@@ -102,24 +103,27 @@ def _cleanup_ttl(d: Dict[str, int], ttl: int) -> Dict[str, int]:
 
 def _priority_score(name: str) -> int:
     """Option #3: score by mission value/size using keywords in the title."""
-    n = (name or "").lower()
-    score = 0
-    # example cues (tweak freely)
-    for kw, pts in [
-        ("major", 8),
-        ("mass", 8),
-        ("large", 6),
-        ("multiple", 5),
-        ("high-rise", 5),
-        ("industrial", 4),
-        ("chemical", 4),
-        ("airport", 4),
-        ("brush", 3),
-        ("wildfire", 5),
-    ]:
-        if kw in n:
-            score += pts
-    return score
+    try:
+        return get_priority_score(name)
+    except Exception:
+        n = (name or "").lower()
+        score = 0
+        # example cues (tweak freely)
+        for kw, pts in [
+            ("major", 8),
+            ("mass", 8),
+            ("large", 6),
+            ("multiple", 5),
+            ("high-rise", 5),
+            ("industrial", 4),
+            ("chemical", 4),
+            ("airport", 4),
+            ("brush", 3),
+            ("wildfire", 5),
+        ]:
+            if kw in n:
+                score += pts
+        return score
 
 
 def _classify_type(text: str) -> str | None:

--- a/utils/orchestrator_client.py
+++ b/utils/orchestrator_client.py
@@ -9,6 +9,23 @@ from __future__ import annotations
 import requests
 
 
+def get_priority_score(name: str, url: str = "http://localhost:8080/score") -> int:
+    """Request a priority score for a mission title from the Go service.
+
+    Parameters
+    ----------
+    name: str
+        Mission title to evaluate.
+    url: str, optional
+        Base URL of the Go service.
+    """
+
+    response = requests.get(url, params={"name": name}, timeout=5)
+    response.raise_for_status()
+    data = response.json()
+    return int(data["score"])
+
+
 def get_fibonacci(n: int, url: str = "http://localhost:8080/fib") -> int:
     """Request the nth Fibonacci number from the Go service.
 
@@ -28,3 +45,4 @@ def get_fibonacci(n: int, url: str = "http://localhost:8080/fib") -> int:
 
 if __name__ == "__main__":
     print(get_fibonacci(10))
+    print(get_priority_score("Major wildfire"))


### PR DESCRIPTION
## Summary
- add `/score` endpoint to Go service for mission priority scoring
- expose `get_priority_score` client and use it in dispatcher with Python fallback
- document and demonstrate new endpoint in README

## Testing
- `ruff check utils/orchestrator_client.py utils/dispatcher.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6899f828593883229f915cf9e977425e