### PR TITLE
Use Go service for mission priority scoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,4 +45,5 @@ print(get_priority_score("Major wildfire"))
 ```
 
 This demonstrates delegating performance-critical work to a faster language
-via a simple HTTP API.
+via a simple HTTP API. The dispatcher now relies on this Go service for
+mission priority scoring, so keep it running during normal operation.

--- a/utils/dispatcher.py
+++ b/utils/dispatcher.py
@@ -102,28 +102,12 @@ def _cleanup_ttl(d: Dict[str, int], ttl: int) -> Dict[str, int]:
 
 
 def _priority_score(name: str) -> int:
-    """Option #3: score by mission value/size using keywords in the title."""
+    """Score a mission title using the Go service."""
     try:
         return get_priority_score(name)
-    except Exception:
-        n = (name or "").lower()
-        score = 0
-        # example cues (tweak freely)
-        for kw, pts in [
-            ("major", 8),
-            ("mass", 8),
-            ("large", 6),
-            ("multiple", 5),
-            ("high-rise", 5),
-            ("industrial", 4),
-            ("chemical", 4),
-            ("airport", 4),
-            ("brush", 3),
-            ("wildfire", 5),
-        ]:
-            if kw in n:
-                score += pts
-        return score
+    except Exception as exc:
+        display_error(f"priority score failed: {exc}")
+        return 0
 
 
 def _classify_type(text: str) -> str | None:


### PR DESCRIPTION
## Summary
- Remove Python fallback and delegate mission priority scoring to the Go orchestrator service
- Document that the dispatcher requires the Go service for priority scoring

## Testing
- `black utils/dispatcher.py`
- `ruff check utils/dispatcher.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6899fa6e75488322b645f7ae3e39dfd7