### PR TITLE
feat: collect agent event responses

### DIFF
--- a/agents/README.md
+++ b/agents/README.md
@@ -43,6 +43,14 @@ from agents import emit
 await emit("config_reload")  # ask dynamic config agent to reload
 ```
 
+`emit` can also gather responses from handlers by setting `collect=True`:
+
+```python
+responses = await emit("ping", collect=True)
+for agent, reply in responses.items():
+    print(agent, reply)
+```
+
 Handle events by overriding `on_event`:
 
 ```python


### PR DESCRIPTION
## Summary
- allow `emit` to collect responses from agent event handlers
- document how to gather replies when broadcasting events

## Testing
- `ruff check agents/loader.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6899fc172e9c8322a1689077f69b600f