### PR TITLE
Configure pytest path and fix ruff issues

### DIFF
--- a/Main.py
+++ b/Main.py
@@ -15,11 +15,11 @@ from data.config_settings import (
     get_headless,
     get_mission_delay,
     get_password,
+    get_politeness,
     get_threads,
     get_transport_delay,
     get_transport_prefs,
     get_username,
-    get_politeness,
 )
 from setup.login import launch_with_state, login_and_save_state
 from utils.browser import close_browsers

--- a/agents/cleanup.py
+++ b/agents/cleanup.py
@@ -7,13 +7,12 @@ blacklists to ensure a clean start next run.
 from __future__ import annotations
 
 import json
+from collections.abc import Iterable
 from pathlib import Path
-from typing import Iterable
 
 from utils.pretty_print import display_info
 
 from .base import BaseAgent
-
 
 EPHEMERAL_FILES: tuple[str, ...] = (
     "data/deferred_missions.json",
@@ -45,4 +44,3 @@ class CleanupAgent(BaseAgent):
         display_info("CleanupAgent: clearing ephemeral data files…")
         _reset_json_files(EPHEMERAL_FILES)
         display_info("CleanupAgent: done.")
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,3 +30,6 @@ ignore = [
 quote-style = "preserve"
 indent-style = "space"
 skip-magic-trailing-comma = false
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import sys
+from pathlib import Path
+
+# Ensure project root is on sys.path so tests can import modules
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/utils/transport.py
+++ b/utils/transport.py
@@ -23,7 +23,6 @@ from utils.metrics import inc, maybe_write
 from utils.politeness import ensure_settled, sleep_jitter
 from utils.pretty_print import display_error, display_info
 
-
 DEFER_PATH = Path("data/deferred_transports.json")
 BLACKLIST_PATH = Path("data/destination_blacklist.json")
 ATTEMPT_PATH = Path("data/transport_attempts.json")
@@ -59,7 +58,7 @@ class _Rec:
     first_seen: int
 
     @classmethod
-    def from_dict(cls, d: dict[str, Any], now: int) -> "_Rec":
+    def from_dict(cls, d: dict[str, Any], now: int) -> _Rec:
         return cls(
             next_check=int(d.get("next_check", 0)),
             defer_count=int(d.get("defer_count", 0)),


### PR DESCRIPTION
## Summary
- limit pytest discovery to project tests
- ensure tests can import project modules
- fix ruff lint issues in core modules

## Testing
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689a161979c08322ad4ca657bc7240f3