### PR TITLE
feat: add cache clearing agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Updated documentation and licensing.
 - Reworked update check to track main repository commits and auto-update on startup.
 - Auto-update now pulls new files and restarts the bot when updates are detected.
+- Added cache clearing agent to periodically purge cached configuration values.
 
 ## 2025-08-10 — v2.0
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Maintainer: **HGFantasy** — License: **MIT**
 ## Highlights
 - Agent-based architecture with an inter-agent event bus for runtime coordination.
 - Command-file and dynamic-config agents enable hot reloads and runtime controls.
+- Cache clearing agent purges cached configuration values periodically.
 - HumanAgent delivers adaptive human-like pacing; missions can be deferred and agents toggled on the fly.
 - GitHub update alerts, metrics summaries, and ambulance-only dispatch mode.
 - Cached config getters and precompiled mission-type checks for smoother performance.

--- a/agents/cache_clear.py
+++ b/agents/cache_clear.py
@@ -1,0 +1,40 @@
+"""Agent to periodically clear cached configuration getters."""
+
+from __future__ import annotations
+
+import time
+
+from data.config_settings import clear_cache
+from utils.pretty_print import display_info
+
+from .base import BaseAgent
+
+
+class CacheClearAgent(BaseAgent):
+    """Clears cached configuration values at a fixed interval."""
+
+    def __init__(self) -> None:
+        self._interval = 300.0  # seconds
+        self._last_clear = 0.0
+
+    async def on_start(self, **_: dict) -> None:
+        self._last_clear = time.monotonic()
+
+    async def on_mission_tick(self, **_: dict) -> None:
+        await self._maybe_clear()
+
+    async def on_transport_tick(self, **_: dict) -> None:
+        await self._maybe_clear()
+
+    async def on_event(self, event: str, **_: dict) -> None:
+        if event == "cache_clear":
+            clear_cache()
+            display_info("Cache cleared")
+            self._last_clear = time.monotonic()
+
+    async def _maybe_clear(self) -> None:
+        now = time.monotonic()
+        if now - self._last_clear >= self._interval:
+            clear_cache()
+            display_info("Cache cleared")
+            self._last_clear = now

--- a/data/config_settings.py
+++ b/data/config_settings.py
@@ -283,9 +283,14 @@ def get_disabled_agents():
     return [x.strip() for x in raw.split(",") if x.strip()]
 
 
+def clear_cache() -> None:
+    """Clear cached config getter functions."""
+    for f in _CACHED_FUNCS:
+        f.cache_clear()
+
+
 def reload_config() -> None:
     """Reload configuration from disk for hot-reload agents."""
     if CONFIG_PATH.exists():
         config.read(CONFIG_PATH, encoding="utf-8")
-        for f in _CACHED_FUNCS:
-            f.cache_clear()
+        clear_cache()


### PR DESCRIPTION
## Summary
- add `CacheClearAgent` to periodically clear cached configuration values
- expose `clear_cache` helper in `data.config_settings` and reuse in reload
- document new agent in README and changelog

## Testing
- `ruff check data/config_settings.py agents/cache_clear.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689a2ee587288322b1435d23759fea4d