### PR TITLE
docs: finalize v2.0 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+- No unreleased changes.
+
+## 2025-08-11 — v2.0
+
+- Switched to an agent-based architecture with a central event bus for runtime coordination.
+- Dynamic configuration and command-file agents allow hot reloads and runtime controls.
+- HumanAgent provides fatigue-aware pacing; missions can be deferred and agents toggled on the fly.
+- Added GitHub update notifications, metrics summaries, and ambulance-only dispatch mode.
+- Optimized configuration lookups and dispatch classification, and removed obsolete legacy scripts.
 - Load environment variables from a `.env` file at startup.
 - Launch authenticated browsers concurrently for faster startup.
 - Simplified configuration validation for clarity.
@@ -10,14 +19,6 @@
 - Auto-update now pulls new files and restarts the bot when updates are detected.
 - Added cache clearing agent to periodically purge cached configuration values.
 - Cache clearing agent now wipes mission and transport cache files.
-
-## 2025-08-10 — v2.0
-
-- Switched to an agent-based architecture with a central event bus for runtime coordination.
-- Dynamic configuration and command-file agents allow hot reloads and runtime controls.
-- HumanAgent provides fatigue-aware pacing; missions can be deferred and agents toggled on the fly.
-- Added GitHub update notifications, metrics summaries, and ambulance-only dispatch mode.
-- Optimized configuration lookups and dispatch classification, and removed obsolete legacy scripts.
 
 ## 2025-08-09 — v1.0 public release
 

--- a/README.md
+++ b/README.md
@@ -4,12 +4,14 @@ Maintainer: **HGFantasy** — License: **MIT**
 ## Highlights
 - Agent-based architecture with an inter-agent event bus for runtime coordination.
 - Command-file and dynamic-config agents enable hot reloads and runtime controls.
-- Cache clearing agent purges cached configuration values and data caches periodically.
+- Cache clearing agent purges cached configuration values and mission/transport caches periodically.
 - HumanAgent delivers adaptive human-like pacing; missions can be deferred and agents toggled on the fly.
 - GitHub update alerts, metrics summaries, and ambulance-only dispatch mode.
+- Update check tracks main repository commits and auto-updates by pulling new files and restarting automatically.
 - Cached config getters and precompiled mission-type checks for smoother performance.
 - Environment variables can be loaded from a `.env` file.
 - Browsers launch concurrently for faster startup.
+- Simplified configuration validation for clarity.
 
 ## Quickstart (Windows PowerShell)
 ```powershell

--- a/agents/README.md
+++ b/agents/README.md
@@ -4,6 +4,10 @@ MscBot supports a lightweight agent system. Each `*.py` file inside the
 `agents/` directory is inspected on start. Any class deriving from
 `BaseAgent` will be instantiated automatically.
 
+Built-in agents such as `update_check`, `cache_clear`, `command_file`, and
+`dynamic_config` provide reference implementations and useful runtime
+features.
+
 ## Creating an agent
 
 1. Create a new module in `agents/` (e.g. `my_agent.py`).


### PR DESCRIPTION
## Summary
- Move unreleased changelog entries into the v2.0 section and set release date to 2025-08-11
- Clarify README highlights for cache clearing, auto-update, and configuration validation
- Note available built-in agents in the agent development guide

## Testing
- `black --check .` *(reports several files would be reformatted)*
- `ruff check .`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689a31eea74883228c06f82d1f881bd1