### PR TITLE
feat: require Python 3.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Unreleased
 
-- No unreleased changes.
+- Require Python 3.14+ and update docs accordingly.
+- Use `asyncio.TaskGroup` for concurrent mission and transport loops.
 
 ## 2025-08-11 — v2.0
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 Thanks for helping improve MscBot!
 
 ## Getting started
-1. Install Python 3.13+
+1. Install Python 3.14+
 2. Create a virtual environment:
    ```bash
    python -m venv .venv

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Maintainer: **HGFantasy** — License: **MIT**
 ## Quickstart (Windows PowerShell)
 ```powershell
 Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass
-py -3.13 -m venv .venv
+py -3.14 -m venv .venv
 .\.venv\Scripts\Activate.ps1
 .\.venv\Scripts\python.exe -m pip install -r requirements.txt
 .\.venv\Scripts\python.exe -m playwright install


### PR DESCRIPTION
## Summary
- adopt `asyncio.TaskGroup` for browser launch and run loops
- document Python 3.14 as the required version

## Testing
- `black Main.py`
- `ruff check Main.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689a343f7ab88322a22d7e0cf93a8d25