### PR TITLE
Require Python 3.13 runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Require Python 3.14+ and update docs accordingly.
+- Require Python 3.13+ and update docs accordingly.
 - Use `asyncio.TaskGroup` for concurrent mission and transport loops.
 
 ## 2025-08-11 — v2.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 Thanks for helping improve MscBot!
 
 ## Getting started
-1. Install Python 3.14+
+1. Install Python 3.13+
 2. Create a virtual environment:
    ```bash
    python -m venv .venv

--- a/Main.py
+++ b/Main.py
@@ -2,8 +2,12 @@
 # Maintained by: HGFantasy
 # License: MIT
 
+import sys
 import asyncio
 from pathlib import Path
+
+if sys.version_info < (3, 13):
+    raise RuntimeError("Python 3.13+ is required to run MscBot.")
 
 from dotenv import load_dotenv
 from playwright.async_api import async_playwright

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Maintainer: **HGFantasy** — License: **MIT**
 ## Quickstart (Windows PowerShell)
 ```powershell
 Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass
-py -3.11 -m venv .venv  # or 3.12/3.13/3.14
+py -3.13 -m venv .venv  # or 3.14
 .\.venv\Scripts\Activate.ps1
 .\.venv\Scripts\python.exe -m pip install -r requirements.txt
 .\.venv\Scripts\python.exe -m playwright install


### PR DESCRIPTION
## Summary
- enforce Python 3.13+ at startup
- document Python 3.13 as the minimum supported version

## Testing
- `black Main.py`
- `ruff check Main.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689a3711257c8322ac5ba44b0f671394