### PR TITLE
Modernize codebase for Python 3.13

### DIFF
--- a/Main.py
+++ b/Main.py
@@ -2,12 +2,8 @@
 # Maintained by: HGFantasy
 # License: MIT
 
-import sys
 import asyncio
 from pathlib import Path
-
-if sys.version_info < (3, 13):
-    raise RuntimeError("Python 3.13+ is required to run MscBot.")
 
 from dotenv import load_dotenv
 from playwright.async_api import async_playwright

--- a/agents/defer.py
+++ b/agents/defer.py
@@ -7,7 +7,6 @@ import random
 import time
 from dataclasses import asdict, dataclass
 from pathlib import Path
-from typing import Dict
 
 from data.config_settings import get_defer_config
 from utils.pretty_print import display_info
@@ -25,7 +24,7 @@ class DeferredMission:
     defer_count: int = 0
 
     @classmethod
-    def from_dict(cls, data: Dict[str, object]) -> "DeferredMission":
+    def from_dict(cls, data: dict[str, object]) -> DeferredMission:
         """Create a record from a raw dict."""
         return cls(
             next_check=int(data.get("next_check", 0)),
@@ -40,7 +39,7 @@ class DeferAgent(BaseAgent):
 
     def __init__(self, path: Path | None = None) -> None:
         self.path = path or Path("data/deferred_missions.json")
-        self.defer: Dict[str, DeferredMission] = self._load()
+        self.defer: dict[str, DeferredMission] = self._load()
         cfg = get_defer_config()
         self.enable = bool(cfg.get("enable", True))
         self.dmin = int(cfg.get("min_minutes", 5))
@@ -50,7 +49,7 @@ class DeferAgent(BaseAgent):
         """Return whether the agent is active."""
         return self.enable
 
-    def _load(self) -> Dict[str, DeferredMission]:
+    def _load(self) -> dict[str, DeferredMission]:
         try:
             if self.path.exists():
                 with self.path.open("r", encoding="utf-8") as f:

--- a/agents/dynamic_config.py
+++ b/agents/dynamic_config.py
@@ -1,7 +1,7 @@
 """Agent that hot-reloads config.ini when it changes."""
+
 from __future__ import annotations
 
-from typing import Optional
 
 from data.config_settings import CONFIG_PATH, reload_config
 from utils.pretty_print import display_error, display_info
@@ -12,7 +12,7 @@ from .loader import emit
 
 class DynamicConfigAgent(BaseAgent):
     def __init__(self) -> None:
-        self._last_mtime: Optional[float] = None
+        self._last_mtime: float | None = None
 
     async def on_start(self, **_: dict) -> None:
         if CONFIG_PATH.exists():
@@ -44,8 +44,9 @@ class DynamicConfigAgent(BaseAgent):
             try:
                 reload_config()
                 display_info("config.ini reloaded")
-                self._last_mtime = CONFIG_PATH.stat().st_mtime if CONFIG_PATH.exists() else None
+                self._last_mtime = (
+                    CONFIG_PATH.stat().st_mtime if CONFIG_PATH.exists() else None
+                )
                 await emit("config_reloaded")
             except Exception as e:
                 display_error(f"DynamicConfigAgent reload failed: {e}")
-

--- a/agents/loader.py
+++ b/agents/loader.py
@@ -8,7 +8,7 @@ import inspect
 import pkgutil
 from collections.abc import Awaitable
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any
 
 from data.config_settings import get_enabled_agents, get_disabled_agents
 from utils.pretty_print import display_error, display_info
@@ -16,7 +16,7 @@ from utils.pretty_print import display_error, display_info
 from .base import BaseAgent
 
 
-_AGENTS: Dict[str, BaseAgent] = {}
+_AGENTS: dict[str, BaseAgent] = {}
 _ACTIVE: set[str] = set()
 
 
@@ -62,7 +62,7 @@ def load_agents() -> None:
     display_info(msg)
 
 
-def iter_active_agents() -> List[BaseAgent]:
+def iter_active_agents() -> list[BaseAgent]:
     """Return a list of currently enabled agent instances."""
     return [_AGENTS[n] for n in _ACTIVE]
 
@@ -80,7 +80,7 @@ async def emit(event: str, **kwargs: Any) -> None:
     handler which receives the event name via a keyword argument.
     """
 
-    tasks: List[tuple[str, str, Awaitable[Any]]] = []
+    tasks: list[tuple[str, str, Awaitable[Any]]] = []
     for name in list(_ACTIVE):
         agent = _AGENTS.get(name)
         if not agent:

--- a/utils/backoff.py
+++ b/utils/backoff.py
@@ -1,4 +1,3 @@
-
 # Project: MscBot
 # License: MIT
 
@@ -10,6 +9,7 @@ _cfg = get_backoff_config()
 _factor = 1.0
 _last_good = time.time()
 
+
 def get_delay_factor() -> float:
     global _factor, _last_good
     if time.time() - _last_good > _cfg["cool_down_good_seconds"]:
@@ -17,12 +17,14 @@ def get_delay_factor() -> float:
             _factor = max(1.0, _factor - _cfg["factor_step"])
     return _factor
 
+
 def record_timeout():
     global _factor
     if not _cfg["enable"]:
         return
     _factor = min(_cfg["factor_max"], _factor + _cfg["factor_step"])
     display_info(f"Backoff increased: factor={_factor:.2f}")
+
 
 def record_good():
     global _last_good

--- a/utils/browser.py
+++ b/utils/browser.py
@@ -5,7 +5,7 @@ Utilities for working with Playwright browser instances.
 from __future__ import annotations
 
 import asyncio
-from typing import Iterable
+from collections.abc import Iterable
 
 from utils.pretty_print import display_error, display_info
 

--- a/utils/metrics.py
+++ b/utils/metrics.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import json
 import time
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any
 
 from utils.pretty_print import display_info, display_error
 
@@ -16,7 +16,7 @@ WRITE_INTERVAL_SEC = 60  # ~once a minute
 HEARTBEAT_INTERVAL_SEC = 90  # console health ping
 
 # In-memory counters
-_COUNTERS: Dict[str, int] = {
+_COUNTERS: dict[str, int] = {
     "missions_seen": 0,
     "missions_deferred": 0,
     "missions_dispatched": 0,
@@ -40,7 +40,7 @@ def inc(name: str, n: int = 1) -> None:
     _COUNTERS["updated"] = int(time.time())
 
 
-def snapshot() -> Dict[str, Any]:
+def snapshot() -> dict[str, Any]:
     s = dict(_COUNTERS)
     s["updated"] = int(time.time())
     return s

--- a/utils/mission_data.py
+++ b/utils/mission_data.py
@@ -9,7 +9,7 @@ import json
 import re
 import time
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any
 
 from utils.pretty_print import display_error, display_info
 from utils.politeness import ensure_settled, goto_safe
@@ -18,7 +18,7 @@ SNAPSHOT_PATH = Path("data/mission_data.json")
 MISSION_HREF_RE = re.compile(r"/missions/(\d+)")
 
 
-def _read_existing() -> Dict[str, Any]:
+def _read_existing() -> dict[str, Any]:
     try:
         if SNAPSHOT_PATH.exists():
             with SNAPSHOT_PATH.open("r", encoding="utf-8") as f:
@@ -28,7 +28,7 @@ def _read_existing() -> Dict[str, Any]:
     return {}
 
 
-def _merge_preserving_seen_ts(snapshot: Dict[str, Any]) -> Dict[str, Any]:
+def _merge_preserving_seen_ts(snapshot: dict[str, Any]) -> dict[str, Any]:
     """
     Merge incoming snapshot with existing file, keeping the earliest seen_ts per mission.
     """
@@ -59,7 +59,7 @@ def _merge_preserving_seen_ts(snapshot: Dict[str, Any]) -> Dict[str, Any]:
     return snapshot
 
 
-def write_snapshot(snapshot: Dict[str, Any]) -> None:
+def write_snapshot(snapshot: dict[str, Any]) -> None:
     """
     Write mission snapshot to disk, preserving earliest seen_ts across rewrites.
     If nothing changed since last write, skip the write to reduce churn.
@@ -85,7 +85,7 @@ def write_snapshot(snapshot: Dict[str, Any]) -> None:
     display_info(f"Wrote mission_data.json with {len(snapshot)} missions.")
 
 
-async def _collect_from_page(page) -> Dict[str, Any]:
+async def _collect_from_page(page) -> dict[str, Any]:
     """
     Collect missions from the home page by scanning anchors like /missions/<id>.
     """
@@ -98,7 +98,7 @@ async def _collect_from_page(page) -> Dict[str, Any]:
 
     anchors = page.locator('a[href^="/missions/"]')
     count = await anchors.count()
-    snapshot: Dict[str, Any] = {}
+    snapshot: dict[str, Any] = {}
     now = int(time.time())
 
     for i in range(count):

--- a/utils/politeness.py
+++ b/utils/politeness.py
@@ -15,7 +15,8 @@ import asyncio
 import random
 import time
 from contextlib import asynccontextmanager
-from typing import Any, Awaitable, Callable
+from typing import Any
+from collections.abc import Awaitable, Callable
 
 from data.config_settings import get_page_min_dwell_range
 from utils.auth_repair import ensure_authenticated

--- a/utils/vehicle_options.py
+++ b/utils/vehicle_options.py
@@ -11,11 +11,10 @@ by editing ``BASE_OPTIONS`` below.
 
 from __future__ import annotations
 
-from typing import Dict, List
 
 # Canonical mapping.  Keys may contain multiple aliases separated by commas or
 # "or" which will be expanded into ``VEHICLE_OPTIONS`` at import time.
-BASE_OPTIONS: Dict[str, List[str]] = {
+BASE_OPTIONS: dict[str, list[str]] = {
     "arffs or firetruck": [
         "Type 1 fire engine",
         "Type 2 fire engine",
@@ -24,7 +23,12 @@ BASE_OPTIONS: Dict[str, List[str]] = {
         "Large ARFF Crash Tender",
     ],
     "firetruck": ["Type 1 fire engine", "Type 2 fire engine", "Type 3 fire engine"],
-    "firetrucks or platform truck": ["Type 1 fire engine", "Type 2 fire engine", "Platform truck", "Quint"],
+    "firetrucks or platform truck": [
+        "Type 1 fire engine",
+        "Type 2 fire engine",
+        "Platform truck",
+        "Quint",
+    ],
     "firetrucks, heavy rescue vehicles or platform truck": [
         "Type 1 fire engine",
         "Type 2 fire engine",
@@ -44,7 +48,11 @@ BASE_OPTIONS: Dict[str, List[str]] = {
     "hazmat": ["HazMat"],
     "mobile command vehicle": ["MCV"],
     "fire investigation unit": ["Fire Investigator Unit"],
-    "arff": ["Small ARFF Crash Tender", "Medium ARFF Crash Tender", "Large ARFF Crash Tender"],
+    "arff": [
+        "Small ARFF Crash Tender",
+        "Medium ARFF Crash Tender",
+        "Large ARFF Crash Tender",
+    ],
     "ambulance": ["ALS Ambulance", "BLS Ambulance"],
     "battalion chief unit": ["EMS Chief"],
     "ems chief": ["EMS Chief"],
@@ -56,16 +64,31 @@ BASE_OPTIONS: Dict[str, List[str]] = {
     "police helicopter": ["Police helicopter"],
     "fbi investigation wagon": ["FBI Investigation Wagon"],
     "fbi bomb technician vehicle": ["FBI Bomb Technician Vehicle"],
-    "fbi drones or fbi investigation wagon": ["FBI Investigation Wagon", "FBI Surveillance Drone"],
+    "fbi drones or fbi investigation wagon": [
+        "FBI Investigation Wagon",
+        "FBI Surveillance Drone",
+    ],
     "riot police unit": ["Riot Police Van", "Riot Police Bus"],
     "warden truck": ["Warden's Truck"],
     "police cars or swat suv": ["Patrol car", "SWAT SUV"],
-    "wildland fire engine": ["Type 3 engine", "Type 4 engine", "Type 5 engine", "Type 6 engine", "Type 7 engine"],
-    "wildland fire vehicle": ["Type 3 engine", "Type 4 engine", "Type 5 engine", "Type 6 engine", "Type 7 engine"],
+    "wildland fire engine": [
+        "Type 3 engine",
+        "Type 4 engine",
+        "Type 5 engine",
+        "Type 6 engine",
+        "Type 7 engine",
+    ],
+    "wildland fire vehicle": [
+        "Type 3 engine",
+        "Type 4 engine",
+        "Type 5 engine",
+        "Type 6 engine",
+        "Type 7 engine",
+    ],
 }
 
 # Expanded lookup map with individual aliases.
-VEHICLE_OPTIONS: Dict[str, List[str]] = {}
+VEHICLE_OPTIONS: dict[str, list[str]] = {}
 for key, opts in BASE_OPTIONS.items():
     parts = []
     for token in key.split(","):
@@ -74,7 +97,7 @@ for key, opts in BASE_OPTIONS.items():
         VEHICLE_OPTIONS[alias.lower()] = opts
 
 
-def get_vehicle_options(vehicle_type: str) -> List[str]:
+def get_vehicle_options(vehicle_type: str) -> list[str]:
     """Return recognised vehicle captions for ``vehicle_type``.
 
     Lookup is case-insensitive; an empty list is returned for unknown types.
@@ -84,4 +107,3 @@ def get_vehicle_options(vehicle_type: str) -> List[str]:
 
 
 __all__ = ["get_vehicle_options"]
-


### PR DESCRIPTION
## Summary
- Apply `pyupgrade --py313-plus` to adopt Python 3.13 syntax
- Drop legacy `typing` imports in favor of built-in generics and union types

## Testing
- `ruff check Main.py agents/defer.py agents/dynamic_config.py agents/loader.py utils/backoff.py utils/browser.py utils/dispatcher.py utils/metrics.py utils/mission_data.py utils/politeness.py utils/vehicle_options.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689a3823c9bc832287d01b6ab30f3b23