### PR TITLE
Refactor file handling and agents for Python 3.14 features

### DIFF
--- a/utils/metrics.py
+++ b/utils/metrics.py
@@ -48,8 +48,10 @@ def snapshot() -> dict[str, Any]:
 
 def _write_now() -> None:
     METRICS_PATH.parent.mkdir(parents=True, exist_ok=True)
-    with METRICS_PATH.open("w", encoding="utf-8") as f:
-        json.dump(snapshot(), f, ensure_ascii=False, indent=2)
+    METRICS_PATH.write_text(
+        json.dumps(snapshot(), ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
 
 
 def maybe_write(force: bool = False) -> None:


### PR DESCRIPTION
## Summary
- add asyncio timeouts and pathlib-based writes to building and vehicle data collectors
- refactor DeferAgent to use pathlib and pattern matching
- streamline metrics writing via Path.write_text

## Testing
- `ruff check agents/defer.py utils/building_data.py utils/vehicle_data.py utils/metrics.py`
- `black --check agents/defer.py utils/building_data.py utils/vehicle_data.py utils/metrics.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689a3bb074908322b3d74c7566454dc8