### PR TITLE
refactor: use TaskGroup and document Python 3.13+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,9 @@
 # Changelog
 
-## Unreleased
+## 2025-08-11 — v2.0
 
 - Require Python 3.13+ and update docs accordingly.
 - Use `asyncio.TaskGroup` for concurrent mission and transport loops.
-
-## 2025-08-11 — v2.0
-
 - Switched to an agent-based architecture with a central event bus for runtime coordination.
 - Dynamic configuration and command-file agents allow hot reloads and runtime controls.
 - HumanAgent provides fatigue-aware pacing; missions can be deferred and agents toggled on the fly.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # MscBot v2.0
 Maintainer: **HGFantasy** — License: **MIT**
+Requires Python 3.13+.
 
 ## Highlights
 - Agent-based architecture with an inter-agent event bus for runtime coordination.
@@ -12,6 +13,7 @@ Maintainer: **HGFantasy** — License: **MIT**
 - Environment variables can be loaded from a `.env` file.
 - Browsers launch concurrently for faster startup.
 - Simplified configuration validation for clarity.
+- Concurrent loops leverage `asyncio.TaskGroup` for robust error handling.
 
 ## Quickstart (Windows PowerShell)
 ```powershell

--- a/agents/README.md
+++ b/agents/README.md
@@ -1,5 +1,7 @@
 # Agent Development Guide
 
+Requires Python 3.13+.
+
 MscBot supports a lightweight agent system. Each `*.py` file inside the
 `agents/` directory is inspected on start. Any class deriving from
 `BaseAgent` will be instantiated automatically.
@@ -55,6 +57,9 @@ class MyAgent(BaseAgent):
         if event == "config_reloaded":
             print("config updated!")
 ```
+
+Events are delivered concurrently to agents using `asyncio.TaskGroup`, so a slow
+or failing handler will not block others.
 
 ## Enabling or disabling agents
 


### PR DESCRIPTION
## Summary
- replace asyncio.gather with TaskGroup for browser shutdowns and agent event dispatch
- consolidate changelog into v2.0 and document Python 3.13+ requirement
- refresh docs to highlight new TaskGroup concurrency model

## Testing
- `black agents/loader.py utils/browser.py`
- `ruff check agents/loader.py utils/browser.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689a43999718832283aa3452e4b61e6e